### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 SHELL = /bin/bash
 
 .SUFFIXES:
-.SUFFIXES: .md .yml .jpg .png .svg .pdf
+.SUFFIXES: .md .yml .jpg .png .svg .pdf .yaml
 
 OUTPUT_DIR = out
 DOCNAME = 'recipes.pdf'
 METADATA = metadata.yml
 LAYOUT = layout.yml
-RECIPES = $(wildcard recipes/*.yml)
+RECIPES = $(wildcard recipes/*.yml) $(wildcard recipes/*.yaml)
 BODY = body.md
 SRC_FILES = $(METADATA) $(RECIPES) $(LAYOUT)
 


### PR DESCRIPTION
Add support for both `.yml` and `.yaml` recipe files.

I may have made a mistake when using it and made a `recipe.yaml` file and then `make` was very sad that my amazing recipe was not found, so to prevent mistakes like that in the future I have added `.yaml` files to the list that it will include. 