### PR TITLE
add support for an optional amounts field

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ The recipe format is loosely based on the [Open Recipe Format](https://open-reci
            - name: Turnip
            - name: Onion
    ```
+ - Specifying the `amount`.
+   Sometimes a recipe needs a mix of amounts, (ie. 1 cup, 2 tps.) so there is an
+   optional `amounts` dict that can be used instead of `amount`.
+
+   ```yml
+   ingredients:
+     - name: Flour
+       amounts:
+        - amount: 1
+          unit: cup.
+        - amount: 2
+          unit: tsp.
+   ```
 
  - The `steps` list is split into `prep` and `method` lists.
    Hazard control points are not currently supported.

--- a/template/tufte.latex
+++ b/template/tufte.latex
@@ -341,7 +341,7 @@ $if(it.ingredients)$
 \begin{itemize}
 $for(it.ingredients)$
   \item{%
-  $it.name$ $if(it.amount)$($it.amount$$if(it.unit)$$it.unit$$endif$)$elseif(it.amounts)$($for(it.amounts)$$it.amount$$if(it.unit)$$it.unit$$endif$$endfor$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$
+  $it.name$ $if(it.amount)$($it.amount$$if(it.unit)$$it.unit$$endif$)$elseif(it.amounts)$($for(it.amounts)$$it.amount$$if(it.unit)$$it.unit$$endif$$sep$, $endfor$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$
     $if(it.substitutions)$
     \newline {\itshape Substitutions}$if(it.substitutions.hint)$ ($it.substitutions.hint$)$endif$:
       \vspace{-6pt plus 2pt minus 2pt}

--- a/template/tufte.latex
+++ b/template/tufte.latex
@@ -341,13 +341,13 @@ $if(it.ingredients)$
 \begin{itemize}
 $for(it.ingredients)$
   \item{%
-  $it.name$ $if(it.amount)$($it.amount$$if(it.unit)$$it.unit$$endif$)$elseif(it.amounts)$($for(it.amounts)$$it.amount$$if(it.unit)$$it.unit$$endif$$sep$, $endfor$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$
+  $it.name$$if(it.amount)$ ($it.amount$$if(it.unit)$ $it.unit$$endif$)$elseif(it.amounts)$ ($for(it.amounts)$$it.amount$$if(it.unit)$ $it.unit$$endif$$sep$, $endfor$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$
     $if(it.substitutions)$
     \newline {\itshape Substitutions}$if(it.substitutions.hint)$ ($it.substitutions.hint$)$endif$:
       \vspace{-6pt plus 2pt minus 2pt}
       \begin{itemize}
       $for(it.substitutions.list)$
-        \item {$it.name$$if(it.amount)$ ($it.amount$$if(it.unit)$ $it.unit$$endif$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$}
+        \item {$it.name$$if(it.amount)$ ($it.amount$$if(it.unit)$ $it.unit$$endif$)$elseif(it.amounts)$ ($for(it.amounts)$$it.amount$$if(it.unit)$ $it.unit$$endif$$sep$, $endfor$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$}
       $endfor$
       \end{itemize}
     $endif$

--- a/template/tufte.latex
+++ b/template/tufte.latex
@@ -341,7 +341,7 @@ $if(it.ingredients)$
 \begin{itemize}
 $for(it.ingredients)$
   \item{%
-    $it.name$$if(it.amount)$ ($it.amount$$if(it.unit)$ $it.unit$$endif$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$
+  $it.name$ $if(it.amount)$($it.amount$$if(it.unit)$$it.unit$$endif$)$elseif(it.amounts)$($for(it.amounts)$$it.amount$$if(it.unit)$$it.unit$$endif$$endfor$)$endif$$if(it.processing)$---$it.processing$$endif$$if(it.notes)$\,\sidenote[][]{$it.notes$}$endif$
     $if(it.substitutions)$
     \newline {\itshape Substitutions}$if(it.substitutions.hint)$ ($it.substitutions.hint$)$endif$:
       \vspace{-6pt plus 2pt minus 2pt}


### PR DESCRIPTION
Sometimes you need to specify more than one measurement (ie 2 cups, 2 table spoons). and now it is possible to do that. 

This is not quite how the [amounts](https://open-recipe-format.readthedocs.io/en/latest/topics/reference/orf.html#amounts) field was meant to be used, but in my opinion it fits this purpose as well. 