### PR TITLE
fixes multiple authors being specified

### DIFF
--- a/template/tufte.latex
+++ b/template/tufte.latex
@@ -154,7 +154,7 @@ $endif$
 % Authorship.
 
 $if(author)$
-\author{$for(author)$$it.first$ $it.last$$sep$\linebreak $endfor$} % Author
+\author{$for(author)$$it.first$ $it.last$$sep$, $endfor$} % Author
 $endif$
 
 % Publisher


### PR DESCRIPTION
Closes #5 

The multiple authors wont each be on their own line, but it will work to specify more than one, and they will be in a coma separated list.